### PR TITLE
Updates to tests and routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,9 @@
     "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"
   },
+  "jest": {
+    "testMatch": [ "**/?(*.)+(test).[jt]s?(x)" ]
+  },
   "eslintConfig": {
     "extends": "airbnb"
   },

--- a/frontend/src/.shared/styles.tsx
+++ b/frontend/src/.shared/styles.tsx
@@ -1,0 +1,133 @@
+import {
+  makeStyles,
+  Theme,
+  createStyles,
+  styled,
+  withTheme
+} from '@material-ui/core/styles';
+import { red, purple, blue } from '@material-ui/core/colors';
+import {
+  Card,
+  CardHeader,
+  CardMedia,
+  CardContent,
+  CardActions,
+  Collapse,
+  Avatar,
+  IconButton,
+  Typography,
+  TextField,
+  Chip,
+  Badge,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+} from '@material-ui/core';
+const primaryFontColor = 'white';
+const primaryBrandColor = blue[200];
+const secondaryBrandColor = red[200];
+
+export const ListContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  [theme.breakpoints.down('sm')]: {
+    width: '94%',
+  },
+  [theme.breakpoints.up('md')]: {
+    width: '60%',
+  },
+}));
+
+export const SiteCardContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+}));
+
+
+export const SiteCard = styled(Card)(({ theme }) => ({
+  width: '100%',
+  marginTop: 20,
+  backgroundColor: 'rgba(255,255,255,0.05)',
+}));
+
+export const SiteCardHeader = styled(CardHeader)(({ theme }) => ({
+  textAlign: 'center',
+  fontWeight: 600,
+  fontSize: 15,
+  color: primaryFontColor,
+}));
+
+export const CardTitle = styled(Typography)(({ theme }) => ({
+  textAlign: 'center',
+  fontWeight: 600,
+  fontSize: 15,
+  color: primaryFontColor,
+}));
+
+export const CardContentPrimary = styled(Typography)(({ theme }) => ({
+  textAlign: 'center',
+  fontWeight: 400,
+  fontSize: 15,
+  color: primaryFontColor,
+}));
+
+export const makeCardListStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    listContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      [theme.breakpoints.down('sm')]: {
+        width: '94%',
+      },
+      [theme.breakpoints.up('md')]: {
+        width: '60%',
+      },
+    },
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+    rideCard: {
+      width: '100%',
+      marginTop: 20,
+      backgroundColor: 'rgba(255,255,255,0.05)',
+    },
+    avatar: {
+      backgroundColor: red[500],
+    },
+    media: {
+      height: 0,
+      paddingTop: '56.25%',
+    },
+    cardHeader: {
+      textAlign: 'center',
+      fontWeight: 600,
+      fontSize: 15,
+      color: primaryFontColor,
+    },
+    cardSubheader: {
+      textAlign: 'center',
+      color: primaryFontColor,
+      fontSize: 12,
+    },
+    cardContent: {
+      textAlign: 'left',
+      color: primaryFontColor,
+      marginBottom: 10,
+    },
+    iconButton: {
+      color: primaryBrandColor,
+      '&:hover, &.Mui-focusVisible': {
+        backgroundColor: 'rgba(255,255,255,0.12)',
+      },
+    },
+    icon: {
+      color: primaryFontColor,
+    },
+  })
+);
+

--- a/frontend/src/.shared/styles.tsx
+++ b/frontend/src/.shared/styles.tsx
@@ -25,9 +25,6 @@ import {
   ListItemText,
   Divider,
 } from '@material-ui/core';
-const primaryFontColor = 'white';
-const primaryBrandColor = blue[200];
-const secondaryBrandColor = red[200];
 
 export const ListContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -57,77 +54,19 @@ export const SiteCardHeader = styled(CardHeader)(({ theme }) => ({
   textAlign: 'center',
   fontWeight: 600,
   fontSize: 15,
-  color: primaryFontColor,
+  color: theme.palette.text.primary,
 }));
 
 export const CardTitle = styled(Typography)(({ theme }) => ({
   textAlign: 'center',
   fontWeight: 600,
   fontSize: 15,
-  color: primaryFontColor,
+  color: theme.palette.text.primary,
 }));
 
 export const CardContentPrimary = styled(Typography)(({ theme }) => ({
   textAlign: 'center',
   fontWeight: 400,
   fontSize: 15,
-  color: primaryFontColor,
+  color: theme.palette.text.primary,
 }));
-
-export const makeCardListStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    listContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      [theme.breakpoints.down('sm')]: {
-        width: '94%',
-      },
-      [theme.breakpoints.up('md')]: {
-        width: '60%',
-      },
-    },
-    root: {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-    },
-    rideCard: {
-      width: '100%',
-      marginTop: 20,
-      backgroundColor: 'rgba(255,255,255,0.05)',
-    },
-    avatar: {
-      backgroundColor: red[500],
-    },
-    media: {
-      height: 0,
-      paddingTop: '56.25%',
-    },
-    cardHeader: {
-      textAlign: 'center',
-      fontWeight: 600,
-      fontSize: 15,
-      color: primaryFontColor,
-    },
-    cardSubheader: {
-      textAlign: 'center',
-      color: primaryFontColor,
-      fontSize: 12,
-    },
-    cardContent: {
-      textAlign: 'left',
-      color: primaryFontColor,
-      marginBottom: 10,
-    },
-    iconButton: {
-      color: primaryBrandColor,
-      '&:hover, &.Mui-focusVisible': {
-        backgroundColor: 'rgba(255,255,255,0.12)',
-      },
-    },
-    icon: {
-      color: primaryFontColor,
-    },
-  })
-);
-

--- a/frontend/src/__tests__/Drawer.test.tsx
+++ b/frontend/src/__tests__/Drawer.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import '@testing-library/jest-dom/extend-expect';
+import { server, LargeWrapper, tags } from './__mocks__';
+import Drawer from '../navigation/Drawer';
+
+const siteNavigation = ['Profile', 'RideFeed'];
+
+beforeAll(() => server.listen());
+afterAll(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const toggleDrawer = (open: boolean) => (
+  event: React.KeyboardEvent | React.MouseEvent
+) => {};
+
+describe('<Drawer />', () => {
+  it('should render site navigation links', () => {
+    const drawer = render(
+      <Router>
+        <Drawer open toggleDrawer={toggleDrawer} />
+      </Router>,
+      {
+        wrapper: LargeWrapper,
+      }
+    );
+    siteNavigation.forEach((section) => {
+      expect(drawer.getByText(section)).toBeInTheDocument();
+    });
+  });
+
+  it('should render Trending Tags section', () => {
+    const drawer = render(
+      <Router>
+        <Drawer open toggleDrawer={toggleDrawer} />
+      </Router>,
+      {
+        wrapper: LargeWrapper,
+      }
+    );
+    expect(drawer.getByText(/Trending Tags/)).toBeInTheDocument();
+  });
+
+  it('should render tags', async () => {
+    const drawer = render(
+      <Router>
+        <Drawer open toggleDrawer={toggleDrawer} />
+      </Router>,
+      {
+        wrapper: LargeWrapper,
+      }
+    );
+    await waitFor(() =>
+      expect(drawer.getByText(`#${tags[0].name}`)).toBeInTheDocument()
+    );
+    tags.forEach((tag) => {
+      const name = `#${tag.name}`;
+      const count = `${tag.tag_count} ${tag.tag_count > 1 ? 'rides' : 'ride'}`;
+      expect(drawer.getByText(name)).toBeInTheDocument();
+      expect(drawer.getByText(count)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/Profile.test.tsx
+++ b/frontend/src/__tests__/Profile.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { Ride, Tag, Comment } from '../types';
+import { BACKEND_URL } from '../config';
+import Profile from '../views/Profile';
+import type { User, UserProfile } from '../types';
+
+const user: User = {
+  id: 1,
+  username: 'test_user',
+  email: 'test@mail.com',
+  is_active: true,
+  is_superuser: false,
+};
+
+const userProfile: UserProfile = {
+  reddit_handle: 'test_reddit_handle',
+  peloton_handle: 'test_peloton_handle',
+  location: 'California',
+  avatar: 'http://test.com/image.png',
+  bio: 'This is a test bio for test user.',
+};
+
+const server = setupServer(
+  rest.get(`${BACKEND_URL}/users/me`, (req, res, ctx) => {
+    return res(ctx.json(user));
+  }),
+
+  rest.get(`${BACKEND_URL}/users/1/profile`, (req, res, ctx) => {
+    return res(ctx.json(userProfile));
+  })
+);
+
+beforeAll(() => server.listen());
+afterAll(() => server.resetHandlers());
+afterAll(() => server.close());
+
+it('should render Profile page', async () => {
+  const profile = render(<Profile />);
+  expect(profile.getByText(/my profile/i)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(profile.getByText(user.username)).toBeInTheDocument();
+  });
+  expect(profile.getByText(user.username)).toBeInTheDocument();
+  expect(profile.getByText(userProfile.reddit_handle)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/Profile.test.tsx
+++ b/frontend/src/__tests__/Profile.test.tsx
@@ -1,38 +1,8 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
-import { Ride, Tag, Comment } from '../types';
-import { BACKEND_URL } from '../config';
+import { server, user, userProfile } from './__mocks__';
 import Profile from '../views/Profile';
-import type { User, UserProfile } from '../types';
-
-const user: User = {
-  id: 1,
-  username: 'test_user',
-  email: 'test@mail.com',
-  is_active: true,
-  is_superuser: false,
-};
-
-const userProfile: UserProfile = {
-  reddit_handle: 'test_reddit_handle',
-  peloton_handle: 'test_peloton_handle',
-  location: 'California',
-  avatar: 'http://test.com/image.png',
-  bio: 'This is a test bio for test user.',
-};
-
-const server = setupServer(
-  rest.get(`${BACKEND_URL}/users/me`, (req, res, ctx) => {
-    return res(ctx.json(user));
-  }),
-
-  rest.get(`${BACKEND_URL}/users/1/profile`, (req, res, ctx) => {
-    return res(ctx.json(userProfile));
-  })
-);
 
 beforeAll(() => server.listen());
 afterAll(() => server.resetHandlers());

--- a/frontend/src/__tests__/RideCard.test.tsx
+++ b/frontend/src/__tests__/RideCard.test.tsx
@@ -8,7 +8,6 @@ import { rest } from 'msw';
 import { server, comments, tags, ride as validRide } from './__mocks__';
 import RideCard from '../views/rides/RideCard';
 import { getLocalStringFromTimeStamp } from '../utils';
-import { Ride, Tag, Comment } from '../types';
 import { BACKEND_URL } from '../config';
 
 beforeAll(() => server.listen());
@@ -78,7 +77,7 @@ it('should accept input in the comment field', async () => {
   expect(input.value).toBe(comment.comment);
 });
 
-xit('should update comments after submitting a comment', async () => {
+it('should update comments after submitting a comment', async () => {
   const comment = {
     comment: 'newly added comment',
     id: 44,
@@ -96,19 +95,21 @@ xit('should update comments after submitting a comment', async () => {
   const input = ride.getByPlaceholderText('Add tag(s)') as HTMLInputElement;
 
   server.use(
+    rest.post(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
+      return res.once(ctx.status(201));
+    }),
+
     rest.get(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
       return res.once(ctx.json([comment]));
     })
   );
 
   fireEvent.change(input, { target: { value: comment.comment } });
-  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+  fireEvent.submit(input);
 
   await waitFor(() =>
     expect(screen.getByText(/newly added comment/)).toBeInTheDocument()
   );
   expect(screen.getByText(/newly added comment/)).toBeInTheDocument();
-
-  await waitFor(() => expect(input.value).toBe(''));
   expect(input.value).toBe('');
 });

--- a/frontend/src/__tests__/RideCard.test.tsx
+++ b/frontend/src/__tests__/RideCard.test.tsx
@@ -5,92 +5,11 @@ import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { rest } from 'msw';
-import { setupServer } from 'msw/node';
+import { server, comments, tags, ride as validRide } from './__mocks__';
 import RideCard from '../views/rides/RideCard';
 import { getLocalStringFromTimeStamp } from '../utils';
 import { Ride, Tag, Comment } from '../types';
 import { BACKEND_URL } from '../config';
-
-// jest.mock('../utils/api');
-
-const validRide: Ride = {
-  id: 10,
-  description: 'The ride from hell. Get on this and never get off.',
-  ride_id: '3863ad9c30af4635b3c2be1aea766fff',
-  difficulty_estimate: 7.7485,
-  duration: 1800,
-  fitness_discipline_display_name: 'Tread Bootcamp',
-  image_url:
-    'https://s3.amazonaws.com/peloton-ride-images/dda7988466b2257d89928788fd9711dc08ed95ba/img_1613524141_d4b7d06e1c6044b09af859abff8f21fd.png',
-  instructor_id: '1b79e462bd564b6ca5ec728f1a5c2af0',
-  title: '30 min of hell',
-  original_air_time: '2021-02-16T22:29:00',
-  scheduled_start_time: '2021-02-16T22:35:00',
-};
-
-const comments: Comment[] = [
-  {
-    comment: 'This is a test comment with no tags',
-    id: 44,
-    created_at: '2021-03-09T21:20:29.035720',
-    user: {
-      id: 2,
-      username: 'test_user1',
-      email: 'user1@mail.com',
-      is_active: true,
-      is_superuser: true,
-    },
-  },
-  {
-    comment: 'This comment has #wonderful tags',
-    id: 46,
-    created_at: '2021-03-11T04:49:05.976540',
-    user: {
-      id: 3,
-      username: 'test_user2',
-      email: 'user2@mail.com',
-      is_active: true,
-      is_superuser: false,
-    },
-  },
-  {
-    comment: 'This another comment',
-    id: 46,
-    created_at: '2021-03-11T04:49:05.976540',
-    user: {
-      id: 3,
-      username: 'test_user2',
-      email: 'user2@mail.com',
-      is_active: true,
-      is_superuser: false,
-    },
-  },
-];
-
-const tags: Tag[] = [
-  {
-    name: 'britney',
-    tag_count: 541,
-  },
-  {
-    name: 'awesome',
-    tag_count: 234,
-  },
-  {
-    name: 'test',
-    tag_count: 67,
-  },
-];
-
-const server = setupServer(
-  rest.get(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
-    return res(ctx.json(comments));
-  }),
-
-  rest.get(`${BACKEND_URL}/rides/10/tags`, (req, res, ctx) => {
-    return res(ctx.json(tags));
-  })
-);
 
 beforeAll(() => server.listen());
 afterAll(() => server.close());
@@ -102,7 +21,7 @@ it('should render rides with comments and tags correctly', async () => {
     validRide.original_air_time
   );
 
-  await waitFor(() => screen.getByText(`#britney`));
+  await waitFor(() => screen.getByText(`#${tags[0].name}`));
 
   expect(ride.getByText(validRide.title)).toBeInTheDocument();
   expect(ride.getByText(validRide.description)).toBeInTheDocument();
@@ -159,7 +78,7 @@ it('should accept input in the comment field', async () => {
   expect(input.value).toBe(comment.comment);
 });
 
-it('should update comments after submitting a comment', async () => {
+xit('should update comments after submitting a comment', async () => {
   const comment = {
     comment: 'newly added comment',
     id: 44,
@@ -178,14 +97,18 @@ it('should update comments after submitting a comment', async () => {
 
   server.use(
     rest.get(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
-      return res(ctx.json([comment, ...comments]));
+      return res.once(ctx.json([comment]));
     })
   );
 
   fireEvent.change(input, { target: { value: comment.comment } });
   fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-  waitFor(
-    () => expect(screen.getByText('newly added comment')).toBeInTheDocument
+
+  await waitFor(() =>
+    expect(screen.getByText(/newly added comment/)).toBeInTheDocument()
   );
-  waitFor(() => expect(input.value).toBe(''));
+  expect(screen.getByText(/newly added comment/)).toBeInTheDocument();
+
+  await waitFor(() => expect(input.value).toBe(''));
+  expect(input.value).toBe('');
 });

--- a/frontend/src/__tests__/TopAppBar.test.tsx
+++ b/frontend/src/__tests__/TopAppBar.test.tsx
@@ -2,110 +2,11 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  waitFor,
-  screen,
-  cleanup,
-} from '@testing-library/react';
-import { within } from '@testing-library/dom';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import '@testing-library/jest-dom/extend-expect';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
+import { server, tags } from './__mocks__';
 import TopAppBar from '../navigation/TopAppBar';
-import { BACKEND_URL } from '../config';
-import type { Tag, Ride, Comment } from '../types';
-
-const tags: Tag[] = [
-  {
-    name: 'test',
-    tag_count: 435,
-  },
-  {
-    name: 'tenOutOfTen',
-    tag_count: 234,
-  },
-  {
-    name: 'DoesNotStartWithTe',
-    tag_count: 1,
-  },
-];
-
-const comments: Comment[] = [
-  {
-    comment: 'This is a test comment with no tags',
-    id: 44,
-    created_at: '2021-03-09T21:20:29.035720',
-    user: {
-      id: 2,
-      username: 'test_user1',
-      email: 'user1@mail.com',
-      is_active: true,
-      is_superuser: true,
-    },
-  },
-  {
-    comment: 'This comment has #wonderful tags',
-    id: 46,
-    created_at: '2021-03-11T04:49:05.976540',
-    user: {
-      id: 3,
-      username: 'test_user2',
-      email: 'user2@mail.com',
-      is_active: true,
-      is_superuser: false,
-    },
-  },
-  {
-    comment: 'This another comment',
-    id: 46,
-    created_at: '2021-03-11T04:49:05.976540',
-    user: {
-      id: 3,
-      username: 'test_user2',
-      email: 'user2@mail.com',
-      is_active: true,
-      is_superuser: false,
-    },
-  },
-];
-
-const rides: Ride[] = [
-  {
-    id: 10,
-    description: 'The ride from hell. Get on this and never get off.',
-    ride_id: '3863ad9c30af4635b3c2be1aea766fff',
-    difficulty_estimate: 7.7485,
-    duration: 1800,
-    fitness_discipline_display_name: 'Tread Bootcamp',
-    image_url:
-      'https://s3.amazonaws.com/peloton-ride-images/dda7988466b2257d89928788fd9711dc08ed95ba/img_1613524141_d4b7d06e1c6044b09af859abff8f21fd.png',
-    instructor_id: '1b79e462bd564b6ca5ec728f1a5c2af0',
-    title: '30 min of hell',
-    original_air_time: '2021-02-16T22:29:00',
-    scheduled_start_time: '2021-02-16T22:35:00',
-  },
-];
-
-const server = setupServer(
-  rest.get(`${BACKEND_URL}/tags/`, (req, res, ctx) => {
-    return res(ctx.json(tags));
-  }),
-
-  rest.get(`${BACKEND_URL}/rides/`, (req, res, ctx) => {
-    return res(ctx.json(rides));
-  }),
-
-  rest.get(`${BACKEND_URL}/rides/10`, (req, res, ctx) => {
-    return res(ctx.json(rides[0]));
-  }),
-
-  rest.get(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
-    return res(ctx.json(comments));
-  })
-);
 
 beforeAll(() => server.listen());
 afterAll(() => server.resetHandlers());

--- a/frontend/src/__tests__/TopAppBar.test.tsx
+++ b/frontend/src/__tests__/TopAppBar.test.tsx
@@ -16,135 +16,137 @@ const toggleDrawer = (open: boolean) => (
   event: React.KeyboardEvent | React.MouseEvent
 ) => {};
 
-it('should render the search field', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
+describe('<TopAppBar />', () => {
+  it('should render the search field', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
 
-  expect(appBar.getByLabelText('Tag search')).toBeInTheDocument();
-});
-
-xit('should dropdown when user clicks search field', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
-
-  fireEvent.click(input);
-  expect(screen.getByRole('presentation')).toBeInTheDocument();
-  expect(screen.getByText(/Loading/)).toBeInTheDocument();
-});
-
-it('should accept input in the search field', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
-
-  fireEvent.change(input, { target: { value: 'te' } });
-  expect(input.value).toBe('te');
-});
-
-it('should dynamically render matched tags while typing', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
-  const search = 'te';
-
-  fireEvent.change(input, { target: { value: search } });
-  expect(input.value).toBe(search);
-
-  await waitFor(() => screen.getAllByText(`rides`, { exact: false }));
-
-  tags.forEach((tag) => {
-    expect(appBar.getByText(`#${tag.name}`)).toBeInTheDocument();
-    if (tag.tag_count > 1) {
-      expect(appBar.getByText(`${tag.tag_count} rides`)).toBeInTheDocument();
-    } else {
-      expect(appBar.getByText(`${tag.tag_count} ride`)).toBeInTheDocument();
-    }
+    expect(appBar.getByLabelText('Tag search')).toBeInTheDocument();
   });
-});
 
-it('should not allow users to enter separate words in the search', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
+  xit('should render dropdown when user clicks search field', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
 
-  fireEvent.change(input, { target: { value: 'test string' } });
-  expect(input.value).toBe('teststring');
-});
+    fireEvent.click(input);
+    // expect(screen.getByRole('presentation')).toBeInTheDocument();
+    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+  });
 
-it('should not allow users to search with special characters', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
+  it('should accept input in the search field', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
 
-  fireEvent.change(input, { target: { value: 'test string@#)*(^#|}{' } });
-  expect(input.value).toBe('teststring');
-});
+    fireEvent.change(input, { target: { value: 'te' } });
+    expect(input.value).toBe('te');
+  });
 
-it('should display "No tags found" if no tags are found', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
+  it('should dynamically render matched tags while typing', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
+    const search = 'te';
 
-  fireEvent.change(input, { target: { value: 'nomatchinghashtags' } });
+    fireEvent.change(input, { target: { value: search } });
+    expect(input.value).toBe(search);
 
-  await waitFor(() => screen.getByText(/No tags found/));
-  expect(screen.getByText(/No tags found/)).toBeInTheDocument();
-});
+    await waitFor(() => screen.getAllByText(`rides`, { exact: false }));
 
-it('should display a button to acccess user options menu', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  expect(appBar.getByLabelText('User menu')).toBeInTheDocument();
-});
+    tags.forEach((tag) => {
+      expect(appBar.getByText(`#${tag.name}`)).toBeInTheDocument();
+      if (tag.tag_count > 1) {
+        expect(appBar.getByText(`${tag.tag_count} rides`)).toBeInTheDocument();
+      } else {
+        expect(appBar.getByText(`${tag.tag_count} ride`)).toBeInTheDocument();
+      }
+    });
+  });
 
-it('should display user options when button is clicked', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const button = appBar.getByLabelText('User menu');
-  fireEvent.click(button);
-  expect(appBar.getByText('My Profile')).toBeInTheDocument();
-  expect(appBar.getByText('Sign out')).toBeInTheDocument();
-});
+  it('should prevent inputting multiple words in the search', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
 
-it('should log the user out when clicking Sign out', async () => {
-  const appBar = render(
-    <Router>
-      <TopAppBar isOpen toggleDrawer={toggleDrawer} />
-    </Router>
-  );
-  const button = appBar.getByLabelText('User menu');
-  fireEvent.click(button);
+    fireEvent.change(input, { target: { value: 'test string' } });
+    expect(input.value).toBe('teststring');
+  });
 
-  const logout = appBar.getByText('Sign out');
-  fireEvent.click(logout);
+  it('should not allow users to search with special characters', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
 
-  waitFor(() => expect(screen.getByText('Remember me')).toBeInTheDocument);
+    fireEvent.change(input, { target: { value: 'test string@#)*(^#|}{' } });
+    expect(input.value).toBe('teststring');
+  });
+
+  it('should display "No tags found" if no tags are found', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const input = appBar.getByLabelText('Tag search') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'nomatchinghashtags' } });
+
+    await waitFor(() => screen.getByText(/No tags found/));
+    expect(screen.getByText(/No tags found/)).toBeInTheDocument();
+  });
+
+  it('should display a button to acccess user options menu', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    expect(appBar.getByLabelText('User menu')).toBeInTheDocument();
+  });
+
+  it('should display user options when button is clicked', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const button = appBar.getByLabelText('User menu');
+    fireEvent.click(button);
+    expect(appBar.getByText('My Profile')).toBeInTheDocument();
+    expect(appBar.getByText('Sign out')).toBeInTheDocument();
+  });
+
+  it('should log the user out when clicking Sign out', async () => {
+    const appBar = render(
+      <Router>
+        <TopAppBar isOpen toggleDrawer={toggleDrawer} />
+      </Router>
+    );
+    const button = appBar.getByLabelText('User menu');
+    fireEvent.click(button);
+
+    const logout = appBar.getByText('Sign out');
+    fireEvent.click(logout);
+
+    waitFor(() => expect(screen.getByText('Remember me')).toBeInTheDocument);
+  });
 });

--- a/frontend/src/__tests__/TopAppBar.test.tsx
+++ b/frontend/src/__tests__/TopAppBar.test.tsx
@@ -29,7 +29,7 @@ const tags: Tag[] = [
   },
   {
     name: 'DoesNotStartWithTe',
-    tag_count: 543,
+    tag_count: 1,
   },
 ];
 
@@ -150,7 +150,7 @@ it('should accept input in the search field', async () => {
   expect(input.value).toBe('te');
 });
 
-it('should dynamically render matched tags as user types', async () => {
+it('should dynamically render matched tags while typing', async () => {
   const appBar = render(
     <Router>
       <TopAppBar isOpen toggleDrawer={toggleDrawer} />
@@ -165,8 +165,12 @@ it('should dynamically render matched tags as user types', async () => {
   await waitFor(() => screen.getAllByText(`rides`, { exact: false }));
 
   tags.forEach((tag) => {
-    expect(appBar.getByText(tag.name)).toBeInTheDocument();
-    expect(appBar.getByText(`${tag.tag_count} rides`)).toBeInTheDocument();
+    expect(appBar.getByText(`#${tag.name}`)).toBeInTheDocument();
+    if (tag.tag_count > 1) {
+      expect(appBar.getByText(`${tag.tag_count} rides`)).toBeInTheDocument();
+    } else {
+      expect(appBar.getByText(`${tag.tag_count} ride`)).toBeInTheDocument();
+    }
   });
 });
 

--- a/frontend/src/__tests__/__mocks__/data.tsx
+++ b/frontend/src/__tests__/__mocks__/data.tsx
@@ -1,0 +1,103 @@
+import type { User, UserProfile, Ride, Comment, Tag } from '../../types';
+
+export const tags: Tag[] = [
+  {
+    name: 'test',
+    tag_count: 435,
+  },
+  {
+    name: 'tenOutOfTen',
+    tag_count: 234,
+  },
+  {
+    name: 'DoesNotStartWithTe',
+    tag_count: 1,
+  },
+];
+
+export const user: User = {
+  id: 1,
+  username: 'test_user',
+  email: 'test@mail.com',
+  is_active: true,
+  is_superuser: false,
+};
+
+export const userProfile: UserProfile = {
+  reddit_handle: 'test_reddit_handle',
+  peloton_handle: 'test_peloton_handle',
+  location: 'California',
+  avatar: 'http://test.com/image.png',
+  bio: 'This is a test bio for test user.',
+};
+
+export const ride: Ride = {
+  id: 10,
+  description: 'The ride from hell. Get on this and never get off.',
+  ride_id: '3863ad9c30af4635b3c2be1aea766fff',
+  difficulty_estimate: 7.7485,
+  duration: 1800,
+  fitness_discipline_display_name: 'Tread Bootcamp',
+  image_url:
+    'https://s3.amazonaws.com/peloton-ride-images/dda7988466b2257d89928788fd9711dc08ed95ba/img_1613524141_d4b7d06e1c6044b09af859abff8f21fd.png',
+  instructor_id: '1b79e462bd564b6ca5ec728f1a5c2af0',
+  title: '30 min of hell',
+  original_air_time: '2021-02-16T22:29:00',
+  scheduled_start_time: '2021-02-16T22:35:00',
+};
+
+export const rides: Ride[] = [
+  {
+    id: 10,
+    description: 'The ride from hell. Get on this and never get off.',
+    ride_id: '3863ad9c30af4635b3c2be1aea766fff',
+    difficulty_estimate: 7.7485,
+    duration: 1800,
+    fitness_discipline_display_name: 'Tread Bootcamp',
+    image_url:
+      'https://s3.amazonaws.com/peloton-ride-images/dda7988466b2257d89928788fd9711dc08ed95ba/img_1613524141_d4b7d06e1c6044b09af859abff8f21fd.png',
+    instructor_id: '1b79e462bd564b6ca5ec728f1a5c2af0',
+    title: '30 min of hell',
+    original_air_time: '2021-02-16T22:29:00',
+    scheduled_start_time: '2021-02-16T22:35:00',
+  },
+];
+
+export const comments: Comment[] = [
+  {
+    comment: 'This is a test comment with no tags',
+    id: 44,
+    created_at: '2021-03-09T21:20:29.035720',
+    user: {
+      id: 2,
+      username: 'test_user1',
+      email: 'user1@mail.com',
+      is_active: true,
+      is_superuser: true,
+    },
+  },
+  {
+    comment: 'This comment has #wonderful tags',
+    id: 46,
+    created_at: '2021-03-11T04:49:05.976540',
+    user: {
+      id: 3,
+      username: 'test_user2',
+      email: 'user2@mail.com',
+      is_active: true,
+      is_superuser: false,
+    },
+  },
+  {
+    comment: 'This another comment',
+    id: 46,
+    created_at: '2021-03-11T04:49:05.976540',
+    user: {
+      id: 3,
+      username: 'test_user2',
+      email: 'user2@mail.com',
+      is_active: true,
+      is_superuser: false,
+    },
+  },
+];

--- a/frontend/src/__tests__/__mocks__/index.tsx
+++ b/frontend/src/__tests__/__mocks__/index.tsx
@@ -1,0 +1,3 @@
+export * from './wrappers';
+export * from './server';
+export * from './data';

--- a/frontend/src/__tests__/__mocks__/server.tsx
+++ b/frontend/src/__tests__/__mocks__/server.tsx
@@ -1,10 +1,10 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { BACKEND_URL, BASE_URL } from '../../config';
+import { BACKEND_URL } from '../../config';
 import { user, userProfile, rides, comments, tags } from './data';
 
 export const server = setupServer(
-  rest.post(`${BASE_URL}/api/token`, (req, res, ctx) => {
+  rest.post(`/api/token`, (req, res, ctx) => {
     return res(ctx.json({ message: 'Successful login' }));
   }),
 

--- a/frontend/src/__tests__/__mocks__/server.tsx
+++ b/frontend/src/__tests__/__mocks__/server.tsx
@@ -1,0 +1,34 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { BACKEND_URL } from '../../config';
+import { user, userProfile, rides, comments, tags } from './data';
+
+export const server = setupServer(
+  rest.get(`${BACKEND_URL}/users/me`, (req, res, ctx) => {
+    return res(ctx.json(user));
+  }),
+
+  rest.get(`${BACKEND_URL}/users/1/profile`, (req, res, ctx) => {
+    return res(ctx.json(userProfile));
+  }),
+
+  rest.get(`${BACKEND_URL}/rides/10/comments`, (req, res, ctx) => {
+    return res(ctx.json(comments));
+  }),
+
+  rest.get(`${BACKEND_URL}/rides/10/tags`, (req, res, ctx) => {
+    return res(ctx.json(tags));
+  }),
+
+  rest.get(`${BACKEND_URL}/tags/`, (req, res, ctx) => {
+    return res(ctx.json(tags));
+  }),
+
+  rest.get(`${BACKEND_URL}/rides/`, (req, res, ctx) => {
+    return res(ctx.json(rides));
+  }),
+
+  rest.get(`${BACKEND_URL}/rides/10`, (req, res, ctx) => {
+    return res(ctx.json(rides[0]));
+  })
+);

--- a/frontend/src/__tests__/__mocks__/server.tsx
+++ b/frontend/src/__tests__/__mocks__/server.tsx
@@ -1,9 +1,13 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { BACKEND_URL } from '../../config';
+import { BACKEND_URL, BASE_URL } from '../../config';
 import { user, userProfile, rides, comments, tags } from './data';
 
 export const server = setupServer(
+  rest.post(`${BASE_URL}/api/token`, (req, res, ctx) => {
+    return res(ctx.json({ message: 'Successful login' }));
+  }),
+
   rest.get(`${BACKEND_URL}/users/me`, (req, res, ctx) => {
     return res(ctx.json(user));
   }),

--- a/frontend/src/__tests__/__mocks__/wrappers.tsx
+++ b/frontend/src/__tests__/__mocks__/wrappers.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
+
+type WrapperProps = {
+  children: React.ReactNode;
+};
+
+export const LargeWrapper: React.ReactNode = ({ children }: WrapperProps) => {
+  const theme = createMuiTheme({
+    props: { MuiWithWidth: { initialWidth: 'lg' } },
+  });
+
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+};
+
+export const SmallWrapper: React.ReactNode = ({ children }: WrapperProps) => {
+  const theme = createMuiTheme({
+    props: { MuiWithWidth: { initialWidth: 'sm' } },
+  });
+
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+};

--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -1,71 +1,77 @@
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  waitFor,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { BrowserRouter, Route } from 'react-router-dom';
 import { rest } from 'msw';
 import { server } from './__mocks__';
 import { Login } from '../views';
-import { BASE_URL } from '../config';
 
 beforeAll(() => server.listen());
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-it('Login renders correctly', () => {
-  const login = render(<Login />);
-  expect(login.getByText('Email')).toBeInTheDocument();
-  expect(login.getByText('Password')).toBeInTheDocument();
-  expect(login.getByText('Login')).toBeInTheDocument();
-});
+describe('<Login />', () => {
+  it('Login renders correctly', () => {
+    const login = render(<Login />);
+    expect(login.getByText('Email')).toBeInTheDocument();
+    expect(login.getByText('Password')).toBeInTheDocument();
+    expect(login.getByText('Login')).toBeInTheDocument();
+  });
 
-it('displays error message if login unsuccessful', async () => {
-  const login = render(<Login />);
-  const emailInput = login.getByLabelText(/Email/);
-  const passwordInput = login.getByLabelText(/Password/);
-  const loginButton = login.getByText(/Login/);
+  it('displays error message if login unsuccessful', async () => {
+    const login = render(<Login />);
+    const emailInput = login.getByLabelText(/Email/);
+    const passwordInput = login.getByLabelText(/Password/);
+    const loginButton = login.getByText(/Login/);
 
-  server.use(
-    rest.post(`/api/token`, (req, res, ctx) => {
-      return res.once(
-        ctx.status(401),
-        ctx.json('Incorrect username or password')
-      );
-    })
-  );
+    server.use(
+      rest.post(`/api/token`, (req, res, ctx) => {
+        return res.once(
+          ctx.status(401),
+          ctx.json('Incorrect username or password')
+        );
+      })
+    );
 
-  fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
-  fireEvent.change(passwordInput, { target: { value: 'password1234' } });
-  fireEvent.click(loginButton);
-  await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
-  expect(
-    screen.getByText(/Incorrect username or password/)
-  ).toBeInTheDocument();
-});
+    fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password1234' } });
+    fireEvent.click(loginButton);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(
+      screen.getByText(/Incorrect username or password/)
+    ).toBeInTheDocument();
+  });
 
-xit('Successfully logs user in using Enter', async () => {
-  const login = render(<Login />);
-  const emailInput = login.getByLabelText(/Email/);
-  const passwordInput = login.getByLabelText(/Password/);
-  fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
-  fireEvent.change(passwordInput, { target: { value: 'password1234' } });
-  fireEvent.keyDown(passwordInput, { key: 'Enter', code: 'Enter' });
-  await waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument());
-  expect(screen.getByText('Success')).toBeInTheDocument();
-});
+  it('Successfully logs user in using Enter', async () => {
+    const login = render(
+      <BrowserRouter>
+        <Login />
+        <Route path="/">Home</Route>
+      </BrowserRouter>
+    );
+    const emailInput = login.getByLabelText(/Email/);
+    const passwordInput = login.getByLabelText(/Password/);
+    fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password1234' } });
+    fireEvent.keyDown(passwordInput, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(screen.getByText(/Home/)).toBeInTheDocument());
+    expect(screen.getByText(/Home/)).toBeInTheDocument();
+  });
 
-xit('Successfully logs user in using mouse click', async () => {
-  const login = render(<Login />);
-  const emailInput = login.getByLabelText(/Email/);
-  const passwordInput = login.getByLabelText(/Password/);
-  const loginButton = login.getByText(/Login/);
-  fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
-  fireEvent.change(passwordInput, { target: { value: 'password1234' } });
-  fireEvent.click(loginButton);
-  await waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument());
-  expect(screen.getByText('Success')).toBeInTheDocument();
+  it('Successfully logs user in using mouse click', async () => {
+    const login = render(
+      <BrowserRouter>
+        <Login />
+        <Route path="/">Home</Route>
+      </BrowserRouter>
+    );
+    const emailInput = login.getByLabelText(/Email/);
+    const passwordInput = login.getByLabelText(/Password/);
+    const loginButton = login.getByText(/Login/);
+    fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password1234' } });
+    fireEvent.click(loginButton);
+    await waitFor(() => expect(screen.getByText(/Home/)).toBeInTheDocument());
+    expect(screen.getByText(/Home/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  waitFor,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { rest } from 'msw';
 import { server } from './__mocks__';
 import { Login } from '../views';
+import { BASE_URL } from '../config';
 
 beforeAll(() => server.listen());
 afterAll(() => server.close());
@@ -13,6 +21,30 @@ it('Login renders correctly', () => {
   expect(login.getByText('Email')).toBeInTheDocument();
   expect(login.getByText('Password')).toBeInTheDocument();
   expect(login.getByText('Login')).toBeInTheDocument();
+});
+
+it('displays error message if login unsuccessful', async () => {
+  const login = render(<Login />);
+  const emailInput = login.getByLabelText(/Email/);
+  const passwordInput = login.getByLabelText(/Password/);
+  const loginButton = login.getByText(/Login/);
+
+  server.use(
+    rest.post(`/api/token`, (req, res, ctx) => {
+      return res.once(
+        ctx.status(401),
+        ctx.json('Incorrect username or password')
+      );
+    })
+  );
+
+  fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
+  fireEvent.change(passwordInput, { target: { value: 'password1234' } });
+  fireEvent.click(loginButton);
+  await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  expect(
+    screen.getByText(/Incorrect username or password/)
+  ).toBeInTheDocument();
 });
 
 xit('Successfully logs user in using Enter', async () => {

--- a/frontend/src/__tests__/login.test.tsx
+++ b/frontend/src/__tests__/login.test.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
+import { server } from './__mocks__';
 import { Login } from '../views';
-import { BACKEND_URL } from '../config';
-
-const server = setupServer(
-  rest.get(`${BACKEND_URL}/`, (req, res, ctx) => {
-    return res(ctx.json({ status: 'Success' }));
-  })
-);
 
 beforeAll(() => server.listen());
 afterAll(() => server.close());
@@ -23,17 +15,18 @@ it('Login renders correctly', () => {
   expect(login.getByText('Login')).toBeInTheDocument();
 });
 
-it('Successfully logs user in using Enter', async () => {
+xit('Successfully logs user in using Enter', async () => {
   const login = render(<Login />);
   const emailInput = login.getByLabelText(/Email/);
   const passwordInput = login.getByLabelText(/Password/);
   fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
   fireEvent.change(passwordInput, { target: { value: 'password1234' } });
   fireEvent.keyDown(passwordInput, { key: 'Enter', code: 'Enter' });
-  waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument);
+  await waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument());
+  expect(screen.getByText('Success')).toBeInTheDocument();
 });
 
-it('Successfully logs user in using mouse click', async () => {
+xit('Successfully logs user in using mouse click', async () => {
   const login = render(<Login />);
   const emailInput = login.getByLabelText(/Email/);
   const passwordInput = login.getByLabelText(/Password/);
@@ -41,5 +34,6 @@ it('Successfully logs user in using mouse click', async () => {
   fireEvent.change(emailInput, { target: { value: 'test_user@mail.com' } });
   fireEvent.change(passwordInput, { target: { value: 'password1234' } });
   fireEvent.click(loginButton);
-  waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument);
+  await waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument());
+  expect(screen.getByText('Success')).toBeInTheDocument();
 });

--- a/frontend/src/navigation/AutoCompleteSearch.tsx
+++ b/frontend/src/navigation/AutoCompleteSearch.tsx
@@ -76,9 +76,11 @@ const AutoCompleteSearch = () => {
       renderOption={(option, { selected }) => (
         <>
           <div>
-            <span>{option.name}</span>
+            <span>{`#${option.name}`}</span>
             <br />
-            <span>{`${option.tag_count} rides`}</span>
+            <span>{`${option.tag_count} ${
+              option.tag_count > 1 ? 'rides' : 'ride'
+            }`}</span>
           </div>
         </>
       )}

--- a/frontend/src/navigation/Drawer.tsx
+++ b/frontend/src/navigation/Drawer.tsx
@@ -110,12 +110,8 @@ const ResponsiveDrawer = ({ open, toggleDrawer }: DrawerProps) => {
       <Divider />
       <List>
         {routes.map((route) => (
-          <NavLink to={route.path}>
-            <ListItem
-              button
-              onClick={() => setOptions({ tag: '' })}
-              key={route.name}
-            >
+          <NavLink to={route.path} key={route.name}>
+            <ListItem button onClick={() => setOptions({ tag: '' })}>
               <ListItemIcon>{route.icon}</ListItemIcon>
               <ListItemText primary={route.name} />
             </ListItem>
@@ -128,12 +124,8 @@ const ResponsiveDrawer = ({ open, toggleDrawer }: DrawerProps) => {
           <ListItemText primary="Trending Tags" />
         </ListItem>
         {tags.map((tag) => (
-          <NavLink to="/rides">
-            <ListItem
-              button
-              onClick={() => setOptions({ tag: tag.name })}
-              key={tag.name}
-            >
+          <NavLink to="/rides" key={tag.name}>
+            <ListItem button onClick={() => setOptions({ tag: tag.name })}>
               <ListItemText
                 primary={`#${tag.name}`}
                 secondary={`${tag.tag_count} ${

--- a/frontend/src/navigation/Drawer.tsx
+++ b/frontend/src/navigation/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
   Divider,
   Drawer,
@@ -7,14 +7,20 @@ import {
   ListItemIcon,
   ListItemText,
   Hidden,
+  Typography,
 } from '@material-ui/core';
-import { Inbox } from '@material-ui/icons';
+import { Inbox, Person, DirectionsBike } from '@material-ui/icons';
+import { Link } from 'react-router-dom';
 import {
   makeStyles,
   useTheme,
   Theme,
   createStyles,
+  styled,
 } from '@material-ui/core/styles';
+import { RideOptionsContext } from '../providers/RidesProvider';
+import { getTags } from '../utils/api';
+import type { Tag } from '../types';
 
 const drawerWidth = 240;
 
@@ -53,6 +59,11 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+const NavLink = styled(Link)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  textDecoration: 'none',
+}));
+
 type DrawerProps = {
   open: boolean;
   toggleDrawer: (
@@ -60,33 +71,77 @@ type DrawerProps = {
   ) => (event: React.KeyboardEvent | React.MouseEvent) => void;
 };
 
+const routes = [
+  {
+    name: 'Profile',
+    path: '/profile',
+    icon: <Person />,
+  },
+  {
+    name: 'RideFeed',
+    path: '/rides',
+    icon: <DirectionsBike />,
+  },
+];
+
 const ResponsiveDrawer = ({ open, toggleDrawer }: DrawerProps) => {
   const classes = useStyles();
   const theme = useTheme();
+  const [tags, setTags] = useState<Tag[]>([]);
+  const { setOptions } = useContext(RideOptionsContext);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const tagList = await getTags();
+      if (mounted) {
+        setTags(tagList);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const drawer = (
     <div>
       <div className={classes.toolbar} />
       <Divider />
       <List>
-        {['Tagged Rides', 'Email', 'Test'].map((text) => (
-          <ListItem button key={text}>
-            <ListItemIcon>
-              <Inbox />
-            </ListItemIcon>
-            <ListItemText primary={text} />
-          </ListItem>
+        {routes.map((route) => (
+          <NavLink to={route.path}>
+            <ListItem
+              button
+              onClick={() => setOptions({ tag: '' })}
+              key={route.name}
+            >
+              <ListItemIcon>{route.icon}</ListItemIcon>
+              <ListItemText primary={route.name} />
+            </ListItem>
+          </NavLink>
         ))}
       </List>
       <Divider />
       <List>
-        {['Tagged Rides', 'Email', 'Test'].map((text) => (
-          <ListItem button key={text}>
-            <ListItemIcon>
-              <Inbox />
-            </ListItemIcon>
-            <ListItemText primary={text} />
-          </ListItem>
+        <ListItem key="trending">
+          <ListItemText primary="Trending Tags" />
+        </ListItem>
+        {tags.map((tag) => (
+          <NavLink to="/rides">
+            <ListItem
+              button
+              onClick={() => setOptions({ tag: tag.name })}
+              key={tag.name}
+            >
+              <ListItemText
+                primary={`#${tag.name}`}
+                secondary={`${tag.tag_count} ${
+                  tag.tag_count > 1 ? 'rides' : 'ride'
+                }`}
+              />
+            </ListItem>
+          </NavLink>
         ))}
       </List>
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,14 @@ export type User = {
   is_superuser: boolean;
 };
 
+export type UserProfile = {
+  reddit_handle: string;
+  peloton_handle: string;
+  location: string;
+  avatar: string;
+  bio: string;
+}
+
 export type Comment = {
   id: number;
   comment: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,7 +12,7 @@ export type UserProfile = {
   location: string;
   avatar: string;
   bio: string;
-}
+};
 
 export type Comment = {
   id: number;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -11,6 +11,25 @@ export const debounce = <T extends Function>(cb: T, wait = 250) => {
   return <T>(<any>callable);
 };
 
+export const getCurrentUser = async () => {
+  const token = localStorage.getItem('token');
+  const config = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  const response = await fetch(`${BACKEND_URL}/users/me`, config);
+  const user = response.json();
+  return user;
+};
+
+export const getUserProfile = async (userId: number) => {
+  const response = await fetch(`${BACKEND_URL}/users/${userId}/profile`);
+  const profile = response.json();
+  return profile;
+};
+
 export const getMessage = async () => {
   const response = await fetch(BACKEND_URL);
 

--- a/frontend/src/views/Profile/index.tsx
+++ b/frontend/src/views/Profile/index.tsx
@@ -1,7 +1,86 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import {
+  Card,
+  CardHeader,
+  CardMedia,
+  CardContent,
+  CardActions,
+  Collapse,
+  Avatar,
+  IconButton,
+  Typography,
+  TextField,
+  Chip,
+  Badge,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+} from '@material-ui/core';
+import type { User, UserProfile } from '../../types';
+import { getCurrentUser, getUserProfile } from '../../utils/api';
+import {
+  ListContainer,
+  SiteCardContainer,
+  SiteCard,
+  SiteCardHeader,
+  CardTitle,
+  CardContentPrimary,
+} from '../../.shared/styles';
+
+// Get user model from /users/me
+// Get user follows
+// Get user rides
+// Use user id to request profile info
+// Render user info in UserInfo and ProfilePicture
+// Render follows with Friends
+// Render user rides with Rides
+
+const initProfile = {
+  reddit_handle: '',
+  peloton_handle: '',
+  location: '',
+  avatar: '',
+  bio: '',
+};
 
 const Profile = () => {
-  return <>MY PROFILE</>;
+  const [user, setUser] = useState<User | null>();
+  const [profile, setProfile] = useState<UserProfile>(initProfile);
+  // const cardList = makeCardListStyles();
+
+  useEffect(() => {
+    (async () => {
+      const user = await getCurrentUser();
+      const profile = await getUserProfile(user.id);
+      console.log(profile);
+      setUser(user);
+      setProfile(profile);
+    })();
+  }, []);
+
+  return (
+    <div>
+      <div>MY PROFILE</div>
+      <ListContainer>
+        {user && (
+          <SiteCardContainer>
+            <SiteCard>
+              <SiteCardHeader title={<CardTitle>{user.username}</CardTitle>} />
+              {profile && (
+                <CardContent>
+                  <CardContentPrimary>
+                    {profile.reddit_handle}
+                  </CardContentPrimary>
+                </CardContent>
+              )}
+            </SiteCard>
+          </SiteCardContainer>
+        )}
+      </ListContainer>
+    </div>
+  );
 };
 
 export default Profile;

--- a/frontend/src/views/Profile/index.tsx
+++ b/frontend/src/views/Profile/index.tsx
@@ -54,7 +54,6 @@ const Profile = () => {
     (async () => {
       const user = await getCurrentUser();
       const profile = await getUserProfile(user.id);
-      console.log(profile);
       setUser(user);
       setProfile(profile);
     })();

--- a/frontend/src/views/rides/RideCard.tsx
+++ b/frontend/src/views/rides/RideCard.tsx
@@ -37,7 +37,6 @@ type RideCardProps = {
   ride: Ride;
 };
 
-const primaryFontColor = 'white';
 const primaryBrandColor = blue[200];
 const secondaryBrandColor = red[200];
 
@@ -64,16 +63,16 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'center',
       fontWeight: 600,
       fontSize: 15,
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
     },
     cardSubheader: {
       textAlign: 'center',
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
       fontSize: 12,
     },
     cardContent: {
       textAlign: 'left',
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
       marginBottom: 10,
     },
     iconButton: {
@@ -83,12 +82,12 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     icon: {
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
     },
     tagForm: {
       width: '100%',
       '& label.Mui-unfocused': {
-        color: primaryFontColor,
+        color: theme.palette.text.primary,
       },
       '& label.Mui-focused': {
         color: primaryBrandColor,
@@ -98,7 +97,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     formInput: {
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
     },
     tagContinaer: {
       display: 'flex',
@@ -128,13 +127,13 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     commentUser: {
       fontWeight: 600,
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
     },
     commentText: {
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
     },
     commentListFooter: {
-      color: primaryFontColor,
+      color: theme.palette.text.primary,
       display: 'flex',
       justifyContent: 'center',
       fontSize: 14,
@@ -202,14 +201,22 @@ const RideCard = ({ ride: rideProp }: RideCardProps) => {
   const airDate = getLocalStringFromTimeStamp(ride.original_air_time);
 
   useEffect(() => {
+    let mounted = true;
+
     (async () => {
       const commentsFromAPI = await getRideComments(ride.id);
       const tagsFromAPI = await getRideTags(ride.id);
 
-      setComments(commentsFromAPI);
-      setCommentCount(Math.min(commentsFromAPI.length, 2));
-      setTags(tagsFromAPI);
+      if (mounted) {
+        setComments(commentsFromAPI);
+        setCommentCount(Math.min(commentsFromAPI.length, 2));
+        setTags(tagsFromAPI);
+      }
     })();
+
+    return () => {
+      mounted = false;
+    };
   }, [ride]);
 
   return (


### PR DESCRIPTION
Lots of changes in this PR:

- Drawer no longer contains placeholder content - actual site navigation and tags are displayed
- Tests have been refactored to be more DRY. Mock server and data were moved to __mocks__.
- Tests that were broken due to async logic have been fixed. This was mostly a misunderstanding on my part on.

Next: make API urls relative, if possible, as long as tests do not break. Some have already been converted no problem.

Also, implement and test error handling for fetch requests.